### PR TITLE
fix(js/theme.js): fix button id for shutdown and hibernate

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -32,13 +32,13 @@ $(greeter).on("ready", function(e) {
 
 	/* Bind shutdown, restart hibernate and suspend to the
 	appropriate buttons */
-	$("#buttonPoweroff").click(function() {
+	$("#buttonShutdown").click(function() {
 		greeter.shutdown();
 	});
 	$("#buttonRestart").click(function() {
 		greeter.restart();
 	});
-	$("#hibernate").click(function() {
+	$("#buttonHibernate").click(function() {
 		greeter.hibernate();
 	});
 


### PR DESCRIPTION
Fix button id both shutdown and hibernate.
But hibernate doesn't work well on my machine, I think that if change it to suspend is better.

This PR contains change of #2 .